### PR TITLE
Fix concurrency bug

### DIFF
--- a/cryptography-providers/jdk/src/jvmMain/kotlin/pooling.kt
+++ b/cryptography-providers/jdk/src/jvmMain/kotlin/pooling.kt
@@ -16,11 +16,9 @@ internal sealed class Pooled<T>(protected val instantiate: () -> T) {
         private val pooled = ArrayDeque<T>()
 
         override fun get(): T {
-            synchronized(this) {
-                pooled.firstOrNull()
-            }?.let { return it }
-
-            return instantiate()
+            return synchronized(this) {
+                pooled.removeLastOrNull()
+            } ?: instantiate()
         }
 
         override fun put(value: T) {

--- a/cryptography-providers/jdk/src/jvmTest/kotlin/PoolingTest.kt
+++ b/cryptography-providers/jdk/src/jvmTest/kotlin/PoolingTest.kt
@@ -1,0 +1,33 @@
+package dev.whyoleg.cryptography.providers.jdk
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.test.*
+import kotlin.test.*
+
+class PoolingTest {
+
+    @Test
+    fun testSequentialAccessOnCachedPoolShouldReuseInstance() {
+        var instantiateCount = 0
+        val pool = Pooled.Cached { instantiateCount++; Any() }
+        repeat(3) {
+            pool.use { }
+        }
+        assertEquals(1, instantiateCount)
+    }
+
+    @Test
+    fun testConcurrentAccessOnCachedPoolShouldNotReuseInstances() = runTest {
+        var instantiateCount = 0
+        val pool = Pooled.Cached { instantiateCount++; Any() }
+        pool.use { } // prime the pool with 1 instance; we should not be able to reuse that instance for all 3 concurrent usages below
+        List(3) {
+            launch {
+                pool.use {
+                    delay(1000)
+                }
+            }
+        }.joinAll()
+        assertEquals(3, instantiateCount)
+    }
+}

--- a/cryptography-providers/jdk/src/jvmTest/kotlin/PoolingTest.kt
+++ b/cryptography-providers/jdk/src/jvmTest/kotlin/PoolingTest.kt
@@ -17,7 +17,7 @@ class PoolingTest {
     }
 
     @Test
-    fun testOverlappingUseCachedPool() = runTest {
+    fun testOverlappingUseCachedPool() {
         val pool = Pooled.Cached(::Any)
         val first = pool.use { it }
         pool.use { i1 ->


### PR DESCRIPTION
Thank you for this excellent library!

I ran into unexpected runtime exceptions while decrypting concurrently on the JVM. The issue appears to be due to a typo in `pooling.kt` (see PR). The proposed change fixes the crashes for my use case.