### PR TITLE
Do not sign (and build) artifacts that aren't going to be published

### DIFF
--- a/build-logic/src/main/kotlin/ckbuild.publication.gradle.kts
+++ b/build-logic/src/main/kotlin/ckbuild.publication.gradle.kts
@@ -53,5 +53,5 @@ signing.isRequired = false
 // and so we need to manually create task dependencies to make Gradle happy
 val javadocJar by tasks.registering(Jar::class) { archiveClassifier.set("javadoc") }
 tasks.withType<Sign>().configureEach { dependsOn(javadocJar) }
-tasks.withType<AbstractPublishToMaven>().configureEach { dependsOn(tasks.withType<Sign>()) }
+tasks.withType<AbstractPublishToMaven>().configureEach { mustRunAfter(tasks.withType<Sign>()) }
 publishing.publications.withType<MavenPublication>().configureEach { artifact(javadocJar) }


### PR DESCRIPTION
This commit removes dependency on all signing tasks from each publishing task. This should prevent Gradle from building and signing of all publications when we need to publish only one of them.