### PR TITLE
Add support for encoding/decoding compressed EC keys

### DIFF
--- a/cryptography-core/src/commonMain/kotlin/algorithms/EC.kt
+++ b/cryptography-core/src/commonMain/kotlin/algorithms/EC.kt
@@ -38,10 +38,18 @@ public interface EC<PublicK : EC.PublicKey, PrivateK : EC.PrivateKey, KP : EC.Ke
                 override val name: String get() = "JWK"
             }
 
-            // only uncompressed format is supported
-            // format defined in X963: 04 | X | Y
-            public data object RAW : Format() {
-                override val name: String get() = "RAW"
+            public sealed class RAW : Format() {
+
+                // uncompressed format: 0x04 | X | Y
+                public companion object Uncompressed : RAW() {
+                    override val name: String get() = "RAW"
+                }
+
+                // compressed format: 0x02 | X (odd Y)
+                //                    0x03 | X (even Y)
+                public data object Compressed : RAW() {
+                    override val name: String get() = "RAW/COMPRESSED"
+                }
             }
 
             // SPKI = SubjectPublicKeyInfo

--- a/cryptography-providers-tests/src/commonMain/kotlin/compatibility/EcCompatibilityTest.kt
+++ b/cryptography-providers-tests/src/commonMain/kotlin/compatibility/EcCompatibilityTest.kt
@@ -17,6 +17,7 @@ import kotlin.test.*
 private val publicKeyFormats = listOf(
     EC.PublicKey.Format.JWK,
     EC.PublicKey.Format.RAW,
+    EC.PublicKey.Format.RAW.Compressed,
     EC.PublicKey.Format.DER,
     EC.PublicKey.Format.PEM,
 ).associateBy { it.name }
@@ -84,6 +85,7 @@ abstract class EcCompatibilityTest<PublicK : EC.PublicKey, PrivateK : EC.Private
                     when (format) {
                         EC.PublicKey.Format.JWK -> {}
                         EC.PublicKey.Format.RAW,
+                        EC.PublicKey.Format.RAW.Compressed,
                         EC.PublicKey.Format.DER,
                         EC.PublicKey.Format.PEM,
                                                 -> {

--- a/cryptography-providers/apple/src/commonMain/kotlin/algorithms/SecEcdsa.kt
+++ b/cryptography-providers/apple/src/commonMain/kotlin/algorithms/SecEcdsa.kt
@@ -58,10 +58,11 @@ private class EcdsaPublicKeyDecoder(
 ) : KeyDecoder<EC.PublicKey.Format, ECDSA.PublicKey> {
     override fun decodeFromByteArrayBlocking(format: EC.PublicKey.Format, bytes: ByteArray): ECDSA.PublicKey {
         val rawKey = when (format) {
-            EC.PublicKey.Format.JWK -> error("$format is not supported")
-            EC.PublicKey.Format.RAW -> bytes
-            EC.PublicKey.Format.DER -> decodeDer(bytes)
-            EC.PublicKey.Format.PEM -> decodeDer(unwrapPem(PemLabel.PublicKey, bytes))
+            EC.PublicKey.Format.JWK            -> error("$format is not supported")
+            EC.PublicKey.Format.RAW            -> bytes
+            EC.PublicKey.Format.RAW.Compressed -> error("$format is not supported")
+            EC.PublicKey.Format.DER            -> decodeDer(bytes)
+            EC.PublicKey.Format.PEM            -> decodeDer(unwrapPem(PemLabel.PublicKey, bytes))
         }
         check(rawKey.size == curve.orderSize * 2 + 1) {
             "Invalid raw key size: ${rawKey.size}, expected: ${curve.orderSize * 2 + 1}"
@@ -89,7 +90,7 @@ private class EcdsaPrivateKeyDecoder(
     override fun decodeFromByteArrayBlocking(format: EC.PrivateKey.Format, bytes: ByteArray): ECDSA.PrivateKey {
         val rawKey = when (format) {
             EC.PrivateKey.Format.JWK      -> error("$format is not supported")
-            EC.PrivateKey.Format.RAW -> error("$format is not supported")
+            EC.PrivateKey.Format.RAW      -> error("$format is not supported")
             EC.PrivateKey.Format.DER      -> decodeDerPkcs8(bytes)
             EC.PrivateKey.Format.PEM      -> decodeDerPkcs8(unwrapPem(PemLabel.PrivateKey, bytes))
             EC.PrivateKey.Format.DER.SEC1 -> decodeDerSec1(bytes)
@@ -176,10 +177,11 @@ private class EcdsaPublicKey(
         val rawKey = exportSecKey(publicKey)
 
         return when (format) {
-            EC.PublicKey.Format.JWK -> error("$format is not supported")
-            EC.PublicKey.Format.RAW -> rawKey
-            EC.PublicKey.Format.DER -> encodeDer(rawKey)
-            EC.PublicKey.Format.PEM -> wrapPem(PemLabel.PublicKey, encodeDer(rawKey))
+            EC.PublicKey.Format.JWK            -> error("$format is not supported")
+            EC.PublicKey.Format.RAW            -> rawKey
+            EC.PublicKey.Format.RAW.Compressed -> error("$format is not supported")
+            EC.PublicKey.Format.DER            -> encodeDer(rawKey)
+            EC.PublicKey.Format.PEM            -> wrapPem(PemLabel.PublicKey, encodeDer(rawKey))
         }
     }
 
@@ -212,7 +214,7 @@ private class EcdsaPrivateKey(
         val rawKey = exportSecKey(privateKey)
         return when (format) {
             EC.PrivateKey.Format.JWK      -> error("$format is not supported")
-            EC.PrivateKey.Format.RAW -> rawKey.copyOfRange(curve.orderSize * 2 + 1, curve.orderSize * 3 + 1)
+            EC.PrivateKey.Format.RAW      -> rawKey.copyOfRange(curve.orderSize * 2 + 1, curve.orderSize * 3 + 1)
             EC.PrivateKey.Format.DER      -> encodeDerPkcs8(rawKey)
             EC.PrivateKey.Format.PEM      -> wrapPem(PemLabel.PrivateKey, encodeDerPkcs8(rawKey))
             EC.PrivateKey.Format.DER.SEC1 -> encodeDerEcPrivateKey(rawKey)

--- a/cryptography-providers/openssl3/api/src/commonMain/kotlin/algorithms/Openssl3Ec.kt
+++ b/cryptography-providers/openssl3/api/src/commonMain/kotlin/algorithms/Openssl3Ec.kt
@@ -99,6 +99,17 @@ internal fun encodePublicRawKey(key: CPointer<EVP_PKEY>): ByteArray = memScoped 
     output.ensureSizeExactly(outVar.value.convert())
 }
 
+@OptIn(UnsafeNumber::class)
+internal fun encodePublicRawCompressedKey(key: CPointer<EVP_PKEY>): ByteArray = memScoped {
+    val ecKey = checkError(EVP_PKEY_get1_EC_KEY(key))
+    val ecGroup = checkError(EC_KEY_get0_group(ecKey))
+    val ecPoint = checkError(EC_KEY_get0_public_key(ecKey))
+    val size = checkError(EC_POINT_point2oct(ecGroup, ecPoint, POINT_CONVERSION_COMPRESSED, null, 0.convert(), null))
+    val output = ByteArray(size.convert())
+    checkError(EC_POINT_point2oct(ecGroup, ecPoint, POINT_CONVERSION_COMPRESSED, output.safeRefToU(0), size, null))
+    output
+}
+
 internal fun encodePrivateRawKey(key: CPointer<EVP_PKEY>): ByteArray = memScoped {
     val orderSize = EC_order_size(key)
     val privVar = alloc<CPointerVar<BIGNUM>>()

--- a/cryptography-providers/openssl3/api/src/commonMain/kotlin/algorithms/Openssl3Ecdh.kt
+++ b/cryptography-providers/openssl3/api/src/commonMain/kotlin/algorithms/Openssl3Ecdh.kt
@@ -53,7 +53,7 @@ internal object Openssl3Ecdh : ECDH {
         override fun inputType(format: EC.PublicKey.Format): String = when (format) {
             EC.PublicKey.Format.DER -> "DER"
             EC.PublicKey.Format.PEM -> "PEM"
-            EC.PublicKey.Format.RAW -> error("should not be called: handled explicitly in decodeFromBlocking")
+            EC.PublicKey.Format.RAW, EC.PublicKey.Format.RAW.Compressed -> error("should not be called: handled explicitly in decodeFromBlocking")
             EC.PublicKey.Format.JWK -> error("JWK format is not supported")
         }
 
@@ -122,12 +122,13 @@ internal object Openssl3Ecdh : ECDH {
         override fun outputType(format: EC.PublicKey.Format): String = when (format) {
             EC.PublicKey.Format.DER -> "DER"
             EC.PublicKey.Format.PEM -> "PEM"
-            EC.PublicKey.Format.RAW -> error("should not be called: handled explicitly in encodeToBlocking")
+            EC.PublicKey.Format.RAW, EC.PublicKey.Format.RAW.Compressed -> error("should not be called: handled explicitly in encodeToBlocking")
             EC.PublicKey.Format.JWK -> error("JWK format is not supported")
         }
 
         override fun encodeToByteArrayBlocking(format: EC.PublicKey.Format): ByteArray = when (format) {
             EC.PublicKey.Format.RAW -> encodePublicRawKey(key)
+            EC.PublicKey.Format.RAW.Compressed -> encodePublicRawCompressedKey(key)
             else -> super.encodeToByteArrayBlocking(format)
         }
 

--- a/cryptography-providers/openssl3/api/src/commonMain/kotlin/algorithms/Openssl3Ecdsa.kt
+++ b/cryptography-providers/openssl3/api/src/commonMain/kotlin/algorithms/Openssl3Ecdsa.kt
@@ -55,7 +55,7 @@ internal object Openssl3Ecdsa : ECDSA {
         override fun inputType(format: EC.PublicKey.Format): String = when (format) {
             EC.PublicKey.Format.DER -> "DER"
             EC.PublicKey.Format.PEM -> "PEM"
-            EC.PublicKey.Format.RAW -> error("should not be called: handled explicitly in decodeFromBlocking")
+            EC.PublicKey.Format.RAW, EC.PublicKey.Format.RAW.Compressed -> error("should not be called: handled explicitly in decodeFromBlocking")
             EC.PublicKey.Format.JWK -> error("JWK format is not supported")
         }
 
@@ -124,12 +124,13 @@ internal object Openssl3Ecdsa : ECDSA {
         override fun outputType(format: EC.PublicKey.Format): String = when (format) {
             EC.PublicKey.Format.DER -> "DER"
             EC.PublicKey.Format.PEM -> "PEM"
-            EC.PublicKey.Format.RAW -> error("should not be called: handled explicitly in encodeToBlocking")
+            EC.PublicKey.Format.RAW, EC.PublicKey.Format.RAW.Compressed -> error("should not be called: handled explicitly in encodeToBlocking")
             EC.PublicKey.Format.JWK -> error("JWK format is not supported")
         }
 
         override fun encodeToByteArrayBlocking(format: EC.PublicKey.Format): ByteArray = when (format) {
             EC.PublicKey.Format.RAW -> encodePublicRawKey(key)
+            EC.PublicKey.Format.RAW.Compressed -> encodePublicRawCompressedKey(key)
             else -> super.encodeToByteArrayBlocking(format)
         }
 


### PR DESCRIPTION
This PR add support for `Compressed` and `Uncompressed`(default) format under `RAW` EC Public Key.

- [x] JDK(BC)
- [ ] WebCrypto (WIP)
- [ ] Apple (WIP)
- [x] OpenSSL3