### PR TITLE
Core: Add EdDSA and XDH algorithm interfaces

### DIFF
--- a/cryptography-core/api/cryptography-core.api
+++ b/cryptography-core/api/cryptography-core.api
@@ -418,6 +418,102 @@ public final class dev/whyoleg/cryptography/algorithms/ECDSA$SignatureFormat : j
 	public static fun values ()[Ldev/whyoleg/cryptography/algorithms/ECDSA$SignatureFormat;
 }
 
+public abstract interface class dev/whyoleg/cryptography/algorithms/EdDSA : dev/whyoleg/cryptography/CryptographyAlgorithm {
+	public static final field Companion Ldev/whyoleg/cryptography/algorithms/EdDSA$Companion;
+	public fun getId ()Ldev/whyoleg/cryptography/CryptographyAlgorithmId;
+	public abstract fun keyPairGenerator (Ldev/whyoleg/cryptography/algorithms/EdDSA$Curve;)Ldev/whyoleg/cryptography/materials/key/KeyGenerator;
+	public abstract fun privateKeyDecoder (Ldev/whyoleg/cryptography/algorithms/EdDSA$Curve;)Ldev/whyoleg/cryptography/materials/key/KeyDecoder;
+	public abstract fun publicKeyDecoder (Ldev/whyoleg/cryptography/algorithms/EdDSA$Curve;)Ldev/whyoleg/cryptography/materials/key/KeyDecoder;
+}
+
+public final class dev/whyoleg/cryptography/algorithms/EdDSA$Companion : dev/whyoleg/cryptography/CryptographyAlgorithmId {
+}
+
+public final class dev/whyoleg/cryptography/algorithms/EdDSA$Curve : java/lang/Enum {
+	public static final field Ed25519 Ldev/whyoleg/cryptography/algorithms/EdDSA$Curve;
+	public static final field Ed448 Ldev/whyoleg/cryptography/algorithms/EdDSA$Curve;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/whyoleg/cryptography/algorithms/EdDSA$Curve;
+	public static fun values ()[Ldev/whyoleg/cryptography/algorithms/EdDSA$Curve;
+}
+
+public abstract interface class dev/whyoleg/cryptography/algorithms/EdDSA$KeyPair : dev/whyoleg/cryptography/materials/key/Key {
+	public abstract fun getPrivateKey ()Ldev/whyoleg/cryptography/algorithms/EdDSA$PrivateKey;
+	public abstract fun getPublicKey ()Ldev/whyoleg/cryptography/algorithms/EdDSA$PublicKey;
+}
+
+public abstract interface class dev/whyoleg/cryptography/algorithms/EdDSA$PrivateKey : dev/whyoleg/cryptography/materials/key/EncodableKey {
+	public abstract fun signatureGenerator ()Ldev/whyoleg/cryptography/operations/SignatureGenerator;
+}
+
+public abstract class dev/whyoleg/cryptography/algorithms/EdDSA$PrivateKey$Format : dev/whyoleg/cryptography/materials/key/KeyFormat {
+	public final fun toString ()Ljava/lang/String;
+}
+
+public final class dev/whyoleg/cryptography/algorithms/EdDSA$PrivateKey$Format$DER : dev/whyoleg/cryptography/algorithms/EdDSA$PrivateKey$Format {
+	public static final field INSTANCE Ldev/whyoleg/cryptography/algorithms/EdDSA$PrivateKey$Format$DER;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+}
+
+public final class dev/whyoleg/cryptography/algorithms/EdDSA$PrivateKey$Format$JWK : dev/whyoleg/cryptography/algorithms/EdDSA$PrivateKey$Format {
+	public static final field INSTANCE Ldev/whyoleg/cryptography/algorithms/EdDSA$PrivateKey$Format$JWK;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+}
+
+public final class dev/whyoleg/cryptography/algorithms/EdDSA$PrivateKey$Format$PEM : dev/whyoleg/cryptography/algorithms/EdDSA$PrivateKey$Format {
+	public static final field INSTANCE Ldev/whyoleg/cryptography/algorithms/EdDSA$PrivateKey$Format$PEM;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+}
+
+public final class dev/whyoleg/cryptography/algorithms/EdDSA$PrivateKey$Format$RAW : dev/whyoleg/cryptography/algorithms/EdDSA$PrivateKey$Format {
+	public static final field INSTANCE Ldev/whyoleg/cryptography/algorithms/EdDSA$PrivateKey$Format$RAW;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+}
+
+public abstract interface class dev/whyoleg/cryptography/algorithms/EdDSA$PublicKey : dev/whyoleg/cryptography/materials/key/EncodableKey {
+	public abstract fun signatureVerifier ()Ldev/whyoleg/cryptography/operations/SignatureVerifier;
+}
+
+public abstract class dev/whyoleg/cryptography/algorithms/EdDSA$PublicKey$Format : dev/whyoleg/cryptography/materials/key/KeyFormat {
+	public final fun toString ()Ljava/lang/String;
+}
+
+public final class dev/whyoleg/cryptography/algorithms/EdDSA$PublicKey$Format$DER : dev/whyoleg/cryptography/algorithms/EdDSA$PublicKey$Format {
+	public static final field INSTANCE Ldev/whyoleg/cryptography/algorithms/EdDSA$PublicKey$Format$DER;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+}
+
+public final class dev/whyoleg/cryptography/algorithms/EdDSA$PublicKey$Format$JWK : dev/whyoleg/cryptography/algorithms/EdDSA$PublicKey$Format {
+	public static final field INSTANCE Ldev/whyoleg/cryptography/algorithms/EdDSA$PublicKey$Format$JWK;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+}
+
+public final class dev/whyoleg/cryptography/algorithms/EdDSA$PublicKey$Format$PEM : dev/whyoleg/cryptography/algorithms/EdDSA$PublicKey$Format {
+	public static final field INSTANCE Ldev/whyoleg/cryptography/algorithms/EdDSA$PublicKey$Format$PEM;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+}
+
+public final class dev/whyoleg/cryptography/algorithms/EdDSA$PublicKey$Format$RAW : dev/whyoleg/cryptography/algorithms/EdDSA$PublicKey$Format {
+	public static final field INSTANCE Ldev/whyoleg/cryptography/algorithms/EdDSA$PublicKey$Format$RAW;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+}
+
 public abstract interface class dev/whyoleg/cryptography/algorithms/HKDF : dev/whyoleg/cryptography/CryptographyAlgorithm {
 	public static final field Companion Ldev/whyoleg/cryptography/algorithms/HKDF$Companion;
 	public fun getId ()Ldev/whyoleg/cryptography/CryptographyAlgorithmId;
@@ -687,6 +783,102 @@ public final class dev/whyoleg/cryptography/algorithms/SHA3_512 : dev/whyoleg/cr
 
 public final class dev/whyoleg/cryptography/algorithms/SHA512 : dev/whyoleg/cryptography/CryptographyAlgorithmId {
 	public static final field INSTANCE Ldev/whyoleg/cryptography/algorithms/SHA512;
+}
+
+public abstract interface class dev/whyoleg/cryptography/algorithms/XDH : dev/whyoleg/cryptography/CryptographyAlgorithm {
+	public static final field Companion Ldev/whyoleg/cryptography/algorithms/XDH$Companion;
+	public fun getId ()Ldev/whyoleg/cryptography/CryptographyAlgorithmId;
+	public abstract fun keyPairGenerator (Ldev/whyoleg/cryptography/algorithms/XDH$Curve;)Ldev/whyoleg/cryptography/materials/key/KeyGenerator;
+	public abstract fun privateKeyDecoder (Ldev/whyoleg/cryptography/algorithms/XDH$Curve;)Ldev/whyoleg/cryptography/materials/key/KeyDecoder;
+	public abstract fun publicKeyDecoder (Ldev/whyoleg/cryptography/algorithms/XDH$Curve;)Ldev/whyoleg/cryptography/materials/key/KeyDecoder;
+}
+
+public final class dev/whyoleg/cryptography/algorithms/XDH$Companion : dev/whyoleg/cryptography/CryptographyAlgorithmId {
+}
+
+public final class dev/whyoleg/cryptography/algorithms/XDH$Curve : java/lang/Enum {
+	public static final field X25519 Ldev/whyoleg/cryptography/algorithms/XDH$Curve;
+	public static final field X448 Ldev/whyoleg/cryptography/algorithms/XDH$Curve;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/whyoleg/cryptography/algorithms/XDH$Curve;
+	public static fun values ()[Ldev/whyoleg/cryptography/algorithms/XDH$Curve;
+}
+
+public abstract interface class dev/whyoleg/cryptography/algorithms/XDH$KeyPair : dev/whyoleg/cryptography/materials/key/Key {
+	public abstract fun getPrivateKey ()Ldev/whyoleg/cryptography/algorithms/XDH$PrivateKey;
+	public abstract fun getPublicKey ()Ldev/whyoleg/cryptography/algorithms/XDH$PublicKey;
+}
+
+public abstract interface class dev/whyoleg/cryptography/algorithms/XDH$PrivateKey : dev/whyoleg/cryptography/materials/key/EncodableKey {
+	public abstract fun sharedSecretGenerator ()Ldev/whyoleg/cryptography/operations/SharedSecretGenerator;
+}
+
+public abstract class dev/whyoleg/cryptography/algorithms/XDH$PrivateKey$Format : dev/whyoleg/cryptography/materials/key/KeyFormat {
+	public final fun toString ()Ljava/lang/String;
+}
+
+public final class dev/whyoleg/cryptography/algorithms/XDH$PrivateKey$Format$DER : dev/whyoleg/cryptography/algorithms/XDH$PrivateKey$Format {
+	public static final field INSTANCE Ldev/whyoleg/cryptography/algorithms/XDH$PrivateKey$Format$DER;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+}
+
+public final class dev/whyoleg/cryptography/algorithms/XDH$PrivateKey$Format$JWK : dev/whyoleg/cryptography/algorithms/XDH$PrivateKey$Format {
+	public static final field INSTANCE Ldev/whyoleg/cryptography/algorithms/XDH$PrivateKey$Format$JWK;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+}
+
+public final class dev/whyoleg/cryptography/algorithms/XDH$PrivateKey$Format$PEM : dev/whyoleg/cryptography/algorithms/XDH$PrivateKey$Format {
+	public static final field INSTANCE Ldev/whyoleg/cryptography/algorithms/XDH$PrivateKey$Format$PEM;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+}
+
+public final class dev/whyoleg/cryptography/algorithms/XDH$PrivateKey$Format$RAW : dev/whyoleg/cryptography/algorithms/XDH$PrivateKey$Format {
+	public static final field INSTANCE Ldev/whyoleg/cryptography/algorithms/XDH$PrivateKey$Format$RAW;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+}
+
+public abstract interface class dev/whyoleg/cryptography/algorithms/XDH$PublicKey : dev/whyoleg/cryptography/materials/key/EncodableKey {
+	public abstract fun sharedSecretGenerator ()Ldev/whyoleg/cryptography/operations/SharedSecretGenerator;
+}
+
+public abstract class dev/whyoleg/cryptography/algorithms/XDH$PublicKey$Format : dev/whyoleg/cryptography/materials/key/KeyFormat {
+	public final fun toString ()Ljava/lang/String;
+}
+
+public final class dev/whyoleg/cryptography/algorithms/XDH$PublicKey$Format$DER : dev/whyoleg/cryptography/algorithms/XDH$PublicKey$Format {
+	public static final field INSTANCE Ldev/whyoleg/cryptography/algorithms/XDH$PublicKey$Format$DER;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+}
+
+public final class dev/whyoleg/cryptography/algorithms/XDH$PublicKey$Format$JWK : dev/whyoleg/cryptography/algorithms/XDH$PublicKey$Format {
+	public static final field INSTANCE Ldev/whyoleg/cryptography/algorithms/XDH$PublicKey$Format$JWK;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+}
+
+public final class dev/whyoleg/cryptography/algorithms/XDH$PublicKey$Format$PEM : dev/whyoleg/cryptography/algorithms/XDH$PublicKey$Format {
+	public static final field INSTANCE Ldev/whyoleg/cryptography/algorithms/XDH$PublicKey$Format$PEM;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+}
+
+public final class dev/whyoleg/cryptography/algorithms/XDH$PublicKey$Format$RAW : dev/whyoleg/cryptography/algorithms/XDH$PublicKey$Format {
+	public static final field INSTANCE Ldev/whyoleg/cryptography/algorithms/XDH$PublicKey$Format$RAW;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
 }
 
 public final class dev/whyoleg/cryptography/algorithms/symmetric/SymmetricKeySize {

--- a/cryptography-core/api/cryptography-core.klib.api
+++ b/cryptography-core/api/cryptography-core.klib.api
@@ -551,6 +551,115 @@ abstract interface dev.whyoleg.cryptography.algorithms/ECDSA : dev.whyoleg.crypt
     final object Companion : dev.whyoleg.cryptography/CryptographyAlgorithmId<dev.whyoleg.cryptography.algorithms/ECDSA> // dev.whyoleg.cryptography.algorithms/ECDSA.Companion|null[0]
 }
 
+abstract interface dev.whyoleg.cryptography.algorithms/EdDSA : dev.whyoleg.cryptography/CryptographyAlgorithm { // dev.whyoleg.cryptography.algorithms/EdDSA|null[0]
+    open val id // dev.whyoleg.cryptography.algorithms/EdDSA.id|{}id[0]
+        open fun <get-id>(): dev.whyoleg.cryptography/CryptographyAlgorithmId<dev.whyoleg.cryptography.algorithms/EdDSA> // dev.whyoleg.cryptography.algorithms/EdDSA.id.<get-id>|<get-id>(){}[0]
+
+    abstract fun keyPairGenerator(dev.whyoleg.cryptography.algorithms/EdDSA.Curve): dev.whyoleg.cryptography.materials.key/KeyGenerator<dev.whyoleg.cryptography.algorithms/EdDSA.KeyPair> // dev.whyoleg.cryptography.algorithms/EdDSA.keyPairGenerator|keyPairGenerator(dev.whyoleg.cryptography.algorithms.EdDSA.Curve){}[0]
+    abstract fun privateKeyDecoder(dev.whyoleg.cryptography.algorithms/EdDSA.Curve): dev.whyoleg.cryptography.materials.key/KeyDecoder<dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey.Format, dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey> // dev.whyoleg.cryptography.algorithms/EdDSA.privateKeyDecoder|privateKeyDecoder(dev.whyoleg.cryptography.algorithms.EdDSA.Curve){}[0]
+    abstract fun publicKeyDecoder(dev.whyoleg.cryptography.algorithms/EdDSA.Curve): dev.whyoleg.cryptography.materials.key/KeyDecoder<dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey.Format, dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey> // dev.whyoleg.cryptography.algorithms/EdDSA.publicKeyDecoder|publicKeyDecoder(dev.whyoleg.cryptography.algorithms.EdDSA.Curve){}[0]
+
+    final enum class Curve : kotlin/Enum<dev.whyoleg.cryptography.algorithms/EdDSA.Curve> { // dev.whyoleg.cryptography.algorithms/EdDSA.Curve|null[0]
+        enum entry Ed25519 // dev.whyoleg.cryptography.algorithms/EdDSA.Curve.Ed25519|null[0]
+        enum entry Ed448 // dev.whyoleg.cryptography.algorithms/EdDSA.Curve.Ed448|null[0]
+
+        final val entries // dev.whyoleg.cryptography.algorithms/EdDSA.Curve.entries|#static{}entries[0]
+            final fun <get-entries>(): kotlin.enums/EnumEntries<dev.whyoleg.cryptography.algorithms/EdDSA.Curve> // dev.whyoleg.cryptography.algorithms/EdDSA.Curve.entries.<get-entries>|<get-entries>#static(){}[0]
+
+        final fun valueOf(kotlin/String): dev.whyoleg.cryptography.algorithms/EdDSA.Curve // dev.whyoleg.cryptography.algorithms/EdDSA.Curve.valueOf|valueOf#static(kotlin.String){}[0]
+        final fun values(): kotlin/Array<dev.whyoleg.cryptography.algorithms/EdDSA.Curve> // dev.whyoleg.cryptography.algorithms/EdDSA.Curve.values|values#static(){}[0]
+    }
+
+    abstract interface KeyPair : dev.whyoleg.cryptography.materials.key/Key { // dev.whyoleg.cryptography.algorithms/EdDSA.KeyPair|null[0]
+        abstract val privateKey // dev.whyoleg.cryptography.algorithms/EdDSA.KeyPair.privateKey|{}privateKey[0]
+            abstract fun <get-privateKey>(): dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey // dev.whyoleg.cryptography.algorithms/EdDSA.KeyPair.privateKey.<get-privateKey>|<get-privateKey>(){}[0]
+        abstract val publicKey // dev.whyoleg.cryptography.algorithms/EdDSA.KeyPair.publicKey|{}publicKey[0]
+            abstract fun <get-publicKey>(): dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey // dev.whyoleg.cryptography.algorithms/EdDSA.KeyPair.publicKey.<get-publicKey>|<get-publicKey>(){}[0]
+    }
+
+    abstract interface PrivateKey : dev.whyoleg.cryptography.materials.key/EncodableKey<dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey.Format> { // dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey|null[0]
+        abstract fun signatureGenerator(): dev.whyoleg.cryptography.operations/SignatureGenerator // dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey.signatureGenerator|signatureGenerator(){}[0]
+
+        sealed class Format : dev.whyoleg.cryptography.materials.key/KeyFormat { // dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey.Format|null[0]
+            final fun toString(): kotlin/String // dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey.Format.toString|toString(){}[0]
+
+            final object DER : dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey.Format { // dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey.Format.DER|null[0]
+                final val name // dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey.Format.DER.name|{}name[0]
+                    final fun <get-name>(): kotlin/String // dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey.Format.DER.name.<get-name>|<get-name>(){}[0]
+
+                final fun equals(kotlin/Any?): kotlin/Boolean // dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey.Format.DER.equals|equals(kotlin.Any?){}[0]
+                final fun hashCode(): kotlin/Int // dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey.Format.DER.hashCode|hashCode(){}[0]
+            }
+
+            final object JWK : dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey.Format { // dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey.Format.JWK|null[0]
+                final val name // dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey.Format.JWK.name|{}name[0]
+                    final fun <get-name>(): kotlin/String // dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey.Format.JWK.name.<get-name>|<get-name>(){}[0]
+
+                final fun equals(kotlin/Any?): kotlin/Boolean // dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey.Format.JWK.equals|equals(kotlin.Any?){}[0]
+                final fun hashCode(): kotlin/Int // dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey.Format.JWK.hashCode|hashCode(){}[0]
+            }
+
+            final object PEM : dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey.Format { // dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey.Format.PEM|null[0]
+                final val name // dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey.Format.PEM.name|{}name[0]
+                    final fun <get-name>(): kotlin/String // dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey.Format.PEM.name.<get-name>|<get-name>(){}[0]
+
+                final fun equals(kotlin/Any?): kotlin/Boolean // dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey.Format.PEM.equals|equals(kotlin.Any?){}[0]
+                final fun hashCode(): kotlin/Int // dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey.Format.PEM.hashCode|hashCode(){}[0]
+            }
+
+            final object RAW : dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey.Format { // dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey.Format.RAW|null[0]
+                final val name // dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey.Format.RAW.name|{}name[0]
+                    final fun <get-name>(): kotlin/String // dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey.Format.RAW.name.<get-name>|<get-name>(){}[0]
+
+                final fun equals(kotlin/Any?): kotlin/Boolean // dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey.Format.RAW.equals|equals(kotlin.Any?){}[0]
+                final fun hashCode(): kotlin/Int // dev.whyoleg.cryptography.algorithms/EdDSA.PrivateKey.Format.RAW.hashCode|hashCode(){}[0]
+            }
+        }
+    }
+
+    abstract interface PublicKey : dev.whyoleg.cryptography.materials.key/EncodableKey<dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey.Format> { // dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey|null[0]
+        abstract fun signatureVerifier(): dev.whyoleg.cryptography.operations/SignatureVerifier // dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey.signatureVerifier|signatureVerifier(){}[0]
+
+        sealed class Format : dev.whyoleg.cryptography.materials.key/KeyFormat { // dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey.Format|null[0]
+            final fun toString(): kotlin/String // dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey.Format.toString|toString(){}[0]
+
+            final object DER : dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey.Format { // dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey.Format.DER|null[0]
+                final val name // dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey.Format.DER.name|{}name[0]
+                    final fun <get-name>(): kotlin/String // dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey.Format.DER.name.<get-name>|<get-name>(){}[0]
+
+                final fun equals(kotlin/Any?): kotlin/Boolean // dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey.Format.DER.equals|equals(kotlin.Any?){}[0]
+                final fun hashCode(): kotlin/Int // dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey.Format.DER.hashCode|hashCode(){}[0]
+            }
+
+            final object JWK : dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey.Format { // dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey.Format.JWK|null[0]
+                final val name // dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey.Format.JWK.name|{}name[0]
+                    final fun <get-name>(): kotlin/String // dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey.Format.JWK.name.<get-name>|<get-name>(){}[0]
+
+                final fun equals(kotlin/Any?): kotlin/Boolean // dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey.Format.JWK.equals|equals(kotlin.Any?){}[0]
+                final fun hashCode(): kotlin/Int // dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey.Format.JWK.hashCode|hashCode(){}[0]
+            }
+
+            final object PEM : dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey.Format { // dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey.Format.PEM|null[0]
+                final val name // dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey.Format.PEM.name|{}name[0]
+                    final fun <get-name>(): kotlin/String // dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey.Format.PEM.name.<get-name>|<get-name>(){}[0]
+
+                final fun equals(kotlin/Any?): kotlin/Boolean // dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey.Format.PEM.equals|equals(kotlin.Any?){}[0]
+                final fun hashCode(): kotlin/Int // dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey.Format.PEM.hashCode|hashCode(){}[0]
+            }
+
+            final object RAW : dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey.Format { // dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey.Format.RAW|null[0]
+                final val name // dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey.Format.RAW.name|{}name[0]
+                    final fun <get-name>(): kotlin/String // dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey.Format.RAW.name.<get-name>|<get-name>(){}[0]
+
+                final fun equals(kotlin/Any?): kotlin/Boolean // dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey.Format.RAW.equals|equals(kotlin.Any?){}[0]
+                final fun hashCode(): kotlin/Int // dev.whyoleg.cryptography.algorithms/EdDSA.PublicKey.Format.RAW.hashCode|hashCode(){}[0]
+            }
+        }
+    }
+
+    final object Companion : dev.whyoleg.cryptography/CryptographyAlgorithmId<dev.whyoleg.cryptography.algorithms/EdDSA> // dev.whyoleg.cryptography.algorithms/EdDSA.Companion|null[0]
+}
+
 abstract interface dev.whyoleg.cryptography.algorithms/HKDF : dev.whyoleg.cryptography/CryptographyAlgorithm { // dev.whyoleg.cryptography.algorithms/HKDF|null[0]
     open val id // dev.whyoleg.cryptography.algorithms/HKDF.id|{}id[0]
         open fun <get-id>(): dev.whyoleg.cryptography/CryptographyAlgorithmId<dev.whyoleg.cryptography.algorithms/HKDF> // dev.whyoleg.cryptography.algorithms/HKDF.id.<get-id>|<get-id>(){}[0]
@@ -595,6 +704,115 @@ abstract interface dev.whyoleg.cryptography.algorithms/PBKDF2 : dev.whyoleg.cryp
     open fun secretDerivation(dev.whyoleg.cryptography/CryptographyAlgorithmId<dev.whyoleg.cryptography.algorithms/Digest>, kotlin/Int, dev.whyoleg.cryptography/BinarySize, kotlinx.io.bytestring/ByteString): dev.whyoleg.cryptography.operations/SecretDerivation // dev.whyoleg.cryptography.algorithms/PBKDF2.secretDerivation|secretDerivation(dev.whyoleg.cryptography.CryptographyAlgorithmId<dev.whyoleg.cryptography.algorithms.Digest>;kotlin.Int;dev.whyoleg.cryptography.BinarySize;kotlinx.io.bytestring.ByteString){}[0]
 
     final object Companion : dev.whyoleg.cryptography/CryptographyAlgorithmId<dev.whyoleg.cryptography.algorithms/PBKDF2> // dev.whyoleg.cryptography.algorithms/PBKDF2.Companion|null[0]
+}
+
+abstract interface dev.whyoleg.cryptography.algorithms/XDH : dev.whyoleg.cryptography/CryptographyAlgorithm { // dev.whyoleg.cryptography.algorithms/XDH|null[0]
+    open val id // dev.whyoleg.cryptography.algorithms/XDH.id|{}id[0]
+        open fun <get-id>(): dev.whyoleg.cryptography/CryptographyAlgorithmId<dev.whyoleg.cryptography.algorithms/XDH> // dev.whyoleg.cryptography.algorithms/XDH.id.<get-id>|<get-id>(){}[0]
+
+    abstract fun keyPairGenerator(dev.whyoleg.cryptography.algorithms/XDH.Curve): dev.whyoleg.cryptography.materials.key/KeyGenerator<dev.whyoleg.cryptography.algorithms/XDH.KeyPair> // dev.whyoleg.cryptography.algorithms/XDH.keyPairGenerator|keyPairGenerator(dev.whyoleg.cryptography.algorithms.XDH.Curve){}[0]
+    abstract fun privateKeyDecoder(dev.whyoleg.cryptography.algorithms/XDH.Curve): dev.whyoleg.cryptography.materials.key/KeyDecoder<dev.whyoleg.cryptography.algorithms/XDH.PrivateKey.Format, dev.whyoleg.cryptography.algorithms/XDH.PrivateKey> // dev.whyoleg.cryptography.algorithms/XDH.privateKeyDecoder|privateKeyDecoder(dev.whyoleg.cryptography.algorithms.XDH.Curve){}[0]
+    abstract fun publicKeyDecoder(dev.whyoleg.cryptography.algorithms/XDH.Curve): dev.whyoleg.cryptography.materials.key/KeyDecoder<dev.whyoleg.cryptography.algorithms/XDH.PublicKey.Format, dev.whyoleg.cryptography.algorithms/XDH.PublicKey> // dev.whyoleg.cryptography.algorithms/XDH.publicKeyDecoder|publicKeyDecoder(dev.whyoleg.cryptography.algorithms.XDH.Curve){}[0]
+
+    final enum class Curve : kotlin/Enum<dev.whyoleg.cryptography.algorithms/XDH.Curve> { // dev.whyoleg.cryptography.algorithms/XDH.Curve|null[0]
+        enum entry X25519 // dev.whyoleg.cryptography.algorithms/XDH.Curve.X25519|null[0]
+        enum entry X448 // dev.whyoleg.cryptography.algorithms/XDH.Curve.X448|null[0]
+
+        final val entries // dev.whyoleg.cryptography.algorithms/XDH.Curve.entries|#static{}entries[0]
+            final fun <get-entries>(): kotlin.enums/EnumEntries<dev.whyoleg.cryptography.algorithms/XDH.Curve> // dev.whyoleg.cryptography.algorithms/XDH.Curve.entries.<get-entries>|<get-entries>#static(){}[0]
+
+        final fun valueOf(kotlin/String): dev.whyoleg.cryptography.algorithms/XDH.Curve // dev.whyoleg.cryptography.algorithms/XDH.Curve.valueOf|valueOf#static(kotlin.String){}[0]
+        final fun values(): kotlin/Array<dev.whyoleg.cryptography.algorithms/XDH.Curve> // dev.whyoleg.cryptography.algorithms/XDH.Curve.values|values#static(){}[0]
+    }
+
+    abstract interface KeyPair : dev.whyoleg.cryptography.materials.key/Key { // dev.whyoleg.cryptography.algorithms/XDH.KeyPair|null[0]
+        abstract val privateKey // dev.whyoleg.cryptography.algorithms/XDH.KeyPair.privateKey|{}privateKey[0]
+            abstract fun <get-privateKey>(): dev.whyoleg.cryptography.algorithms/XDH.PrivateKey // dev.whyoleg.cryptography.algorithms/XDH.KeyPair.privateKey.<get-privateKey>|<get-privateKey>(){}[0]
+        abstract val publicKey // dev.whyoleg.cryptography.algorithms/XDH.KeyPair.publicKey|{}publicKey[0]
+            abstract fun <get-publicKey>(): dev.whyoleg.cryptography.algorithms/XDH.PublicKey // dev.whyoleg.cryptography.algorithms/XDH.KeyPair.publicKey.<get-publicKey>|<get-publicKey>(){}[0]
+    }
+
+    abstract interface PrivateKey : dev.whyoleg.cryptography.materials.key/EncodableKey<dev.whyoleg.cryptography.algorithms/XDH.PrivateKey.Format> { // dev.whyoleg.cryptography.algorithms/XDH.PrivateKey|null[0]
+        abstract fun sharedSecretGenerator(): dev.whyoleg.cryptography.operations/SharedSecretGenerator<dev.whyoleg.cryptography.algorithms/XDH.PublicKey> // dev.whyoleg.cryptography.algorithms/XDH.PrivateKey.sharedSecretGenerator|sharedSecretGenerator(){}[0]
+
+        sealed class Format : dev.whyoleg.cryptography.materials.key/KeyFormat { // dev.whyoleg.cryptography.algorithms/XDH.PrivateKey.Format|null[0]
+            final fun toString(): kotlin/String // dev.whyoleg.cryptography.algorithms/XDH.PrivateKey.Format.toString|toString(){}[0]
+
+            final object DER : dev.whyoleg.cryptography.algorithms/XDH.PrivateKey.Format { // dev.whyoleg.cryptography.algorithms/XDH.PrivateKey.Format.DER|null[0]
+                final val name // dev.whyoleg.cryptography.algorithms/XDH.PrivateKey.Format.DER.name|{}name[0]
+                    final fun <get-name>(): kotlin/String // dev.whyoleg.cryptography.algorithms/XDH.PrivateKey.Format.DER.name.<get-name>|<get-name>(){}[0]
+
+                final fun equals(kotlin/Any?): kotlin/Boolean // dev.whyoleg.cryptography.algorithms/XDH.PrivateKey.Format.DER.equals|equals(kotlin.Any?){}[0]
+                final fun hashCode(): kotlin/Int // dev.whyoleg.cryptography.algorithms/XDH.PrivateKey.Format.DER.hashCode|hashCode(){}[0]
+            }
+
+            final object JWK : dev.whyoleg.cryptography.algorithms/XDH.PrivateKey.Format { // dev.whyoleg.cryptography.algorithms/XDH.PrivateKey.Format.JWK|null[0]
+                final val name // dev.whyoleg.cryptography.algorithms/XDH.PrivateKey.Format.JWK.name|{}name[0]
+                    final fun <get-name>(): kotlin/String // dev.whyoleg.cryptography.algorithms/XDH.PrivateKey.Format.JWK.name.<get-name>|<get-name>(){}[0]
+
+                final fun equals(kotlin/Any?): kotlin/Boolean // dev.whyoleg.cryptography.algorithms/XDH.PrivateKey.Format.JWK.equals|equals(kotlin.Any?){}[0]
+                final fun hashCode(): kotlin/Int // dev.whyoleg.cryptography.algorithms/XDH.PrivateKey.Format.JWK.hashCode|hashCode(){}[0]
+            }
+
+            final object PEM : dev.whyoleg.cryptography.algorithms/XDH.PrivateKey.Format { // dev.whyoleg.cryptography.algorithms/XDH.PrivateKey.Format.PEM|null[0]
+                final val name // dev.whyoleg.cryptography.algorithms/XDH.PrivateKey.Format.PEM.name|{}name[0]
+                    final fun <get-name>(): kotlin/String // dev.whyoleg.cryptography.algorithms/XDH.PrivateKey.Format.PEM.name.<get-name>|<get-name>(){}[0]
+
+                final fun equals(kotlin/Any?): kotlin/Boolean // dev.whyoleg.cryptography.algorithms/XDH.PrivateKey.Format.PEM.equals|equals(kotlin.Any?){}[0]
+                final fun hashCode(): kotlin/Int // dev.whyoleg.cryptography.algorithms/XDH.PrivateKey.Format.PEM.hashCode|hashCode(){}[0]
+            }
+
+            final object RAW : dev.whyoleg.cryptography.algorithms/XDH.PrivateKey.Format { // dev.whyoleg.cryptography.algorithms/XDH.PrivateKey.Format.RAW|null[0]
+                final val name // dev.whyoleg.cryptography.algorithms/XDH.PrivateKey.Format.RAW.name|{}name[0]
+                    final fun <get-name>(): kotlin/String // dev.whyoleg.cryptography.algorithms/XDH.PrivateKey.Format.RAW.name.<get-name>|<get-name>(){}[0]
+
+                final fun equals(kotlin/Any?): kotlin/Boolean // dev.whyoleg.cryptography.algorithms/XDH.PrivateKey.Format.RAW.equals|equals(kotlin.Any?){}[0]
+                final fun hashCode(): kotlin/Int // dev.whyoleg.cryptography.algorithms/XDH.PrivateKey.Format.RAW.hashCode|hashCode(){}[0]
+            }
+        }
+    }
+
+    abstract interface PublicKey : dev.whyoleg.cryptography.materials.key/EncodableKey<dev.whyoleg.cryptography.algorithms/XDH.PublicKey.Format> { // dev.whyoleg.cryptography.algorithms/XDH.PublicKey|null[0]
+        abstract fun sharedSecretGenerator(): dev.whyoleg.cryptography.operations/SharedSecretGenerator<dev.whyoleg.cryptography.algorithms/XDH.PrivateKey> // dev.whyoleg.cryptography.algorithms/XDH.PublicKey.sharedSecretGenerator|sharedSecretGenerator(){}[0]
+
+        sealed class Format : dev.whyoleg.cryptography.materials.key/KeyFormat { // dev.whyoleg.cryptography.algorithms/XDH.PublicKey.Format|null[0]
+            final fun toString(): kotlin/String // dev.whyoleg.cryptography.algorithms/XDH.PublicKey.Format.toString|toString(){}[0]
+
+            final object DER : dev.whyoleg.cryptography.algorithms/XDH.PublicKey.Format { // dev.whyoleg.cryptography.algorithms/XDH.PublicKey.Format.DER|null[0]
+                final val name // dev.whyoleg.cryptography.algorithms/XDH.PublicKey.Format.DER.name|{}name[0]
+                    final fun <get-name>(): kotlin/String // dev.whyoleg.cryptography.algorithms/XDH.PublicKey.Format.DER.name.<get-name>|<get-name>(){}[0]
+
+                final fun equals(kotlin/Any?): kotlin/Boolean // dev.whyoleg.cryptography.algorithms/XDH.PublicKey.Format.DER.equals|equals(kotlin.Any?){}[0]
+                final fun hashCode(): kotlin/Int // dev.whyoleg.cryptography.algorithms/XDH.PublicKey.Format.DER.hashCode|hashCode(){}[0]
+            }
+
+            final object JWK : dev.whyoleg.cryptography.algorithms/XDH.PublicKey.Format { // dev.whyoleg.cryptography.algorithms/XDH.PublicKey.Format.JWK|null[0]
+                final val name // dev.whyoleg.cryptography.algorithms/XDH.PublicKey.Format.JWK.name|{}name[0]
+                    final fun <get-name>(): kotlin/String // dev.whyoleg.cryptography.algorithms/XDH.PublicKey.Format.JWK.name.<get-name>|<get-name>(){}[0]
+
+                final fun equals(kotlin/Any?): kotlin/Boolean // dev.whyoleg.cryptography.algorithms/XDH.PublicKey.Format.JWK.equals|equals(kotlin.Any?){}[0]
+                final fun hashCode(): kotlin/Int // dev.whyoleg.cryptography.algorithms/XDH.PublicKey.Format.JWK.hashCode|hashCode(){}[0]
+            }
+
+            final object PEM : dev.whyoleg.cryptography.algorithms/XDH.PublicKey.Format { // dev.whyoleg.cryptography.algorithms/XDH.PublicKey.Format.PEM|null[0]
+                final val name // dev.whyoleg.cryptography.algorithms/XDH.PublicKey.Format.PEM.name|{}name[0]
+                    final fun <get-name>(): kotlin/String // dev.whyoleg.cryptography.algorithms/XDH.PublicKey.Format.PEM.name.<get-name>|<get-name>(){}[0]
+
+                final fun equals(kotlin/Any?): kotlin/Boolean // dev.whyoleg.cryptography.algorithms/XDH.PublicKey.Format.PEM.equals|equals(kotlin.Any?){}[0]
+                final fun hashCode(): kotlin/Int // dev.whyoleg.cryptography.algorithms/XDH.PublicKey.Format.PEM.hashCode|hashCode(){}[0]
+            }
+
+            final object RAW : dev.whyoleg.cryptography.algorithms/XDH.PublicKey.Format { // dev.whyoleg.cryptography.algorithms/XDH.PublicKey.Format.RAW|null[0]
+                final val name // dev.whyoleg.cryptography.algorithms/XDH.PublicKey.Format.RAW.name|{}name[0]
+                    final fun <get-name>(): kotlin/String // dev.whyoleg.cryptography.algorithms/XDH.PublicKey.Format.RAW.name.<get-name>|<get-name>(){}[0]
+
+                final fun equals(kotlin/Any?): kotlin/Boolean // dev.whyoleg.cryptography.algorithms/XDH.PublicKey.Format.RAW.equals|equals(kotlin.Any?){}[0]
+                final fun hashCode(): kotlin/Int // dev.whyoleg.cryptography.algorithms/XDH.PublicKey.Format.RAW.hashCode|hashCode(){}[0]
+            }
+        }
+    }
+
+    final object Companion : dev.whyoleg.cryptography/CryptographyAlgorithmId<dev.whyoleg.cryptography.algorithms/XDH> // dev.whyoleg.cryptography.algorithms/XDH.Companion|null[0]
 }
 
 abstract interface dev.whyoleg.cryptography.materials.key/Key // dev.whyoleg.cryptography.materials.key/Key|null[0]

--- a/cryptography-core/src/commonMain/kotlin/algorithms/EdDSA.kt
+++ b/cryptography-core/src/commonMain/kotlin/algorithms/EdDSA.kt
@@ -1,0 +1,74 @@
+package dev.whyoleg.cryptography.algorithms
+
+import dev.whyoleg.cryptography.*
+import dev.whyoleg.cryptography.materials.key.*
+import dev.whyoleg.cryptography.operations.*
+
+@SubclassOptInRequired(CryptographyProviderApi::class)
+public interface EdDSA : CryptographyAlgorithm {
+    override val id: CryptographyAlgorithmId<EdDSA> get() = Companion
+
+    public companion object : CryptographyAlgorithmId<EdDSA>("EdDSA")
+
+    public enum class Curve { Ed25519, Ed448 }
+
+    public fun publicKeyDecoder(curve: Curve): KeyDecoder<PublicKey.Format, PublicKey>
+    public fun privateKeyDecoder(curve: Curve): KeyDecoder<PrivateKey.Format, PrivateKey>
+    public fun keyPairGenerator(curve: Curve): KeyGenerator<KeyPair>
+
+    @SubclassOptInRequired(CryptographyProviderApi::class)
+    public interface KeyPair : Key {
+        public val publicKey: PublicKey
+        public val privateKey: PrivateKey
+    }
+
+    @SubclassOptInRequired(CryptographyProviderApi::class)
+    public interface PublicKey : EncodableKey<PublicKey.Format> {
+        public fun signatureVerifier(): SignatureVerifier
+
+        public sealed class Format : KeyFormat {
+            final override fun toString(): String = name
+
+            public data object JWK : Format() {
+                override val name: String get() = "JWK"
+            }
+
+            public data object RAW : Format() {
+                override val name: String get() = "RAW"
+            }
+
+            public data object DER : Format() {
+                override val name: String get() = "DER"
+            }
+
+            public data object PEM : Format() {
+                override val name: String get() = "PEM"
+            }
+        }
+    }
+
+    @SubclassOptInRequired(CryptographyProviderApi::class)
+    public interface PrivateKey : EncodableKey<PrivateKey.Format> {
+        public fun signatureGenerator(): SignatureGenerator
+
+        public sealed class Format : KeyFormat {
+            final override fun toString(): String = name
+
+            public data object JWK : Format() {
+                override val name: String get() = "JWK"
+            }
+
+            public data object RAW : Format() {
+                override val name: String get() = "RAW"
+            }
+
+            public data object DER : Format() {
+                override val name: String get() = "DER"
+            }
+
+            public data object PEM : Format() {
+                override val name: String get() = "PEM"
+            }
+        }
+    }
+}

--- a/cryptography-core/src/commonMain/kotlin/algorithms/XDH.kt
+++ b/cryptography-core/src/commonMain/kotlin/algorithms/XDH.kt
@@ -1,0 +1,74 @@
+package dev.whyoleg.cryptography.algorithms
+
+import dev.whyoleg.cryptography.*
+import dev.whyoleg.cryptography.materials.key.*
+import dev.whyoleg.cryptography.operations.*
+
+@SubclassOptInRequired(CryptographyProviderApi::class)
+public interface XDH : CryptographyAlgorithm {
+    override val id: CryptographyAlgorithmId<XDH> get() = Companion
+
+    public companion object : CryptographyAlgorithmId<XDH>("XDH")
+
+    public enum class Curve { X25519, X448 }
+
+    public fun publicKeyDecoder(curve: Curve): KeyDecoder<PublicKey.Format, PublicKey>
+    public fun privateKeyDecoder(curve: Curve): KeyDecoder<PrivateKey.Format, PrivateKey>
+    public fun keyPairGenerator(curve: Curve): KeyGenerator<KeyPair>
+
+    @SubclassOptInRequired(CryptographyProviderApi::class)
+    public interface KeyPair : Key {
+        public val publicKey: PublicKey
+        public val privateKey: PrivateKey
+    }
+
+    @SubclassOptInRequired(CryptographyProviderApi::class)
+    public interface PublicKey : EncodableKey<PublicKey.Format> {
+        public fun sharedSecretGenerator(): SharedSecretGenerator<PrivateKey>
+
+        public sealed class Format : KeyFormat {
+            final override fun toString(): String = name
+
+            public data object JWK : Format() {
+                override val name: String get() = "JWK"
+            }
+
+            public data object RAW : Format() {
+                override val name: String get() = "RAW"
+            }
+
+            public data object DER : Format() {
+                override val name: String get() = "DER"
+            }
+
+            public data object PEM : Format() {
+                override val name: String get() = "PEM"
+            }
+        }
+    }
+
+    @SubclassOptInRequired(CryptographyProviderApi::class)
+    public interface PrivateKey : EncodableKey<PrivateKey.Format> {
+        public fun sharedSecretGenerator(): SharedSecretGenerator<PublicKey>
+
+        public sealed class Format : KeyFormat {
+            final override fun toString(): String = name
+
+            public data object JWK : Format() {
+                override val name: String get() = "JWK"
+            }
+
+            public data object RAW : Format() {
+                override val name: String get() = "RAW"
+            }
+
+            public data object DER : Format() {
+                override val name: String get() = "DER"
+            }
+
+            public data object PEM : Format() {
+                override val name: String get() = "PEM"
+            }
+        }
+    }
+}


### PR DESCRIPTION
What
- Introduce `EdDSA` (Ed25519/Ed448) and `XDH` (X25519/X448) APIs under `algorithms/`.
- Update core API descriptors to include the new types.
- No provider or test changes in this PR.

Why
- Establish a stable API surface for providers to implement and for tests to target, independent of provider wiring.
- Follows ASN.1 prep so providers can import/export keys consistently.

Follow‑ups
- Provider implementations (JDK, OpenSSL3, WebCrypto, CryptoKit) will wire these APIs.
- Tests add default/compatibility suites for these algorithms.
