### PR TITLE
Docs(CryptoKit): Add EdDSA/XDH capability note (Ed25519/X25519 only)

### DIFF
--- a/docs/providers/cryptokit.md
+++ b/docs/providers/cryptokit.md
@@ -8,6 +8,7 @@ For supported targets and algorithms, please consult [Supported primitives secti
 
 * KeyFormat: doesn't support `JWK` key format yet
 * AES.GCM supports only a default tag size of 96 bits
+* EdDSA/XDH: supports only Ed25519 and X25519
 
 ## Example
 


### PR DESCRIPTION
What
- Add a limitation bullet: “EdDSA/XDH: supports only Ed25519 and X25519”.
- No other doc, code, or CI changes.

Why
- Clarify CryptoKit capability per maintainer feedback.