### PR TITLE
Docs(WebCrypto): Add EdDSA/XDH availability note and RFC links

### DIFF
--- a/docs/providers/webcrypto.md
+++ b/docs/providers/webcrypto.md
@@ -9,6 +9,7 @@ For supported targets and algorithms, please consult [Supported primitives secti
 * only `suspend` functions are supported, because `WebCrypto` API is async by default
 * AES.* (browser only): may not support `192 bit` keys
 * AES.CBC: only `padding=true` is supported
+* EdDSA/XDH were added later to WebCrypto and might not be available in all browsers (https://github.com/w3c/webcrypto/pull/362)
 
 ## Example
 
@@ -32,3 +33,6 @@ dependencies {
 [WebCrypto]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API
 
 [Supported primitives section]: index.md#supported-primitives
+ 
+[RFC 8032]: https://www.rfc-editor.org/rfc/rfc8032
+[RFC 7748]: https://www.rfc-editor.org/rfc/rfc7748


### PR DESCRIPTION
What
- Add a limitation bullet linking to w3c/webcrypto#362 about EdDSA/XDH availability across browsers.
- Add RFC references for [RFC 8032] and [RFC 7748].
- No other doc, code, or CI changes.

Why
- Clarify browser availability per maintainer feedback.