### PR TITLE
Docs(JDK): Add EdDSA/XDH availability note

### DIFF
--- a/docs/providers/jdk.md
+++ b/docs/providers/jdk.md
@@ -7,6 +7,7 @@ For supported targets and algorithms, please consult [Supported primitives secti
 ## Limitations
 
 * KeyFormat: doesn't support `JWK` key format yet
+* Algorithm availability: XDH is available since JDK 11; EdDSA generally since newer JDK versions (e.g., 15+)
 
 ## Example
 


### PR DESCRIPTION
What
- Add a limitation bullet: “XDH since JDK 11; EdDSA generally since newer JDK versions”.
- No other doc, code, or CI changes.

Why
- Set expectations on JDK feature availability; aligns with provider behavior.