### PR TITLE
Fix: signature copy offset, CMAC slice, urandom FD

### DIFF
--- a/cryptography-providers/apple/src/commonMain/kotlin/algorithms/SecEcdsa.kt
+++ b/cryptography-providers/apple/src/commonMain/kotlin/algorithms/SecEcdsa.kt
@@ -261,7 +261,7 @@ private class EcdsaRawSignatureGenerator(
         override fun signIntoByteArray(destination: ByteArray, destinationOffset: Int): Int {
             val signature = signToByteArray()
             checkBounds(destination.size, destinationOffset, destinationOffset + signature.size)
-            signature.copyInto(destination, destinationOffset, destinationOffset)
+            signature.copyInto(destination, destinationOffset, 0, signature.size)
             return signature.size
         }
 

--- a/cryptography-providers/apple/src/commonMain/kotlin/internal/SecSignature.kt
+++ b/cryptography-providers/apple/src/commonMain/kotlin/internal/SecSignature.kt
@@ -107,7 +107,7 @@ private class SecSignFunction(
     override fun signIntoByteArray(destination: ByteArray, destinationOffset: Int): Int {
         val signature = signToByteArray()
         checkBounds(destination.size, destinationOffset, destinationOffset + signature.size)
-        signature.copyInto(destination, destinationOffset, destinationOffset)
+        signature.copyInto(destination, destinationOffset, 0, signature.size)
         return signature.size
     }
 

--- a/cryptography-providers/jdk/src/jvmMain/kotlin/algorithms/JdkEcdsa.kt
+++ b/cryptography-providers/jdk/src/jvmMain/kotlin/algorithms/JdkEcdsa.kt
@@ -70,7 +70,8 @@ private class EcdsaRawSignatureGenerator(
         override fun signIntoByteArray(destination: ByteArray, destinationOffset: Int): Int {
             val signature = signToByteArray()
             checkBounds(destination.size, destinationOffset, destinationOffset + signature.size)
-            signature.copyInto(destination, destinationOffset, destinationOffset)
+            // Copy the whole signature into destination at the given offset
+            signature.copyInto(destination, destinationOffset, 0, signature.size)
             return signature.size
         }
 

--- a/cryptography-providers/jdk/src/jvmMain/kotlin/operations/JdkSignatureGenerator.kt
+++ b/cryptography-providers/jdk/src/jvmMain/kotlin/operations/JdkSignatureGenerator.kt
@@ -38,7 +38,7 @@ private class JdkSignFunction(
     override fun signIntoByteArray(destination: ByteArray, destinationOffset: Int): Int {
         val signature = signToByteArray()
         checkBounds(destination.size, destinationOffset, destinationOffset + signature.size)
-        signature.copyInto(destination, destinationOffset, destinationOffset)
+        signature.copyInto(destination, destinationOffset, 0, signature.size)
         return signature.size
     }
 

--- a/cryptography-providers/openssl3/api/src/commonMain/kotlin/algorithms/Openssl3AesCmac.kt
+++ b/cryptography-providers/openssl3/api/src/commonMain/kotlin/algorithms/Openssl3AesCmac.kt
@@ -65,15 +65,15 @@ private class AesCmacSignature(
 
         @OptIn(UnsafeNumber::class)
         override fun update(source: ByteArray, startIndex: Int, endIndex: Int) {
-            // Implementation for updating the CMAC with the provided data
+            // Update CMAC using the requested slice [startIndex, endIndex)
             checkBounds(source.size, startIndex, endIndex)
             val context = context.access()
             source.usePinned {
                 checkError(
                     EVP_MAC_update(
                         ctx = context,
-                        data = it.safeAddressOf(0).reinterpret(),
-                        datalen = source.size.convert()
+                        data = it.safeAddressOf(startIndex).reinterpret(),
+                        datalen = (endIndex - startIndex).convert()
                     )
                 )
             }
@@ -82,7 +82,7 @@ private class AesCmacSignature(
         override fun signIntoByteArray(destination: ByteArray, destinationOffset: Int): Int {
             val signature = signToByteArray()
             checkBounds(destination.size, destinationOffset, destinationOffset + signature.size)
-            signature.copyInto(destination, destinationOffset, destinationOffset)
+            signature.copyInto(destination, destinationOffset, 0, signature.size)
             return signature.size
         }
 

--- a/cryptography-providers/openssl3/api/src/commonMain/kotlin/algorithms/Openssl3Ecdsa.kt
+++ b/cryptography-providers/openssl3/api/src/commonMain/kotlin/algorithms/Openssl3Ecdsa.kt
@@ -174,7 +174,7 @@ private class EcdsaRawSignatureGenerator(
         override fun signIntoByteArray(destination: ByteArray, destinationOffset: Int): Int {
             val signature = signToByteArray()
             checkBounds(destination.size, destinationOffset, destinationOffset + signature.size)
-            signature.copyInto(destination, destinationOffset, destinationOffset)
+            signature.copyInto(destination, destinationOffset, 0, signature.size)
             return signature.size
         }
 

--- a/cryptography-providers/openssl3/api/src/commonMain/kotlin/operations/Openssl3DigestSignatureGenerator.kt
+++ b/cryptography-providers/openssl3/api/src/commonMain/kotlin/operations/Openssl3DigestSignatureGenerator.kt
@@ -46,7 +46,7 @@ internal abstract class Openssl3DigestSignatureGenerator(
         override fun signIntoByteArray(destination: ByteArray, destinationOffset: Int): Int {
             val signature = signToByteArray()
             checkBounds(destination.size, destinationOffset, destinationOffset + signature.size)
-            signature.copyInto(destination, destinationOffset, destinationOffset)
+            signature.copyInto(destination, destinationOffset, 0, signature.size)
             return signature.size
         }
 

--- a/cryptography-random/src/linuxAndAndroidNativeMain/kotlin/URandom.kt
+++ b/cryptography-random/src/linuxAndAndroidNativeMain/kotlin/URandom.kt
@@ -51,6 +51,7 @@ private fun awaitURandomReady() {
 
 private fun open(path: String): Int {
     val fd = open(path, O_RDONLY, null)
-    if (fd <= 0) errnoCheck()
+    // According to POSIX, open returns -1 on error; 0 is a valid descriptor
+    if (fd < 0) errnoCheck()
     return fd
 }


### PR DESCRIPTION
## Summary
Fixes three correctness/security issues:
- Signature copy when writing into a destination buffer with offset: always copy from source index 0 to the given destination offset (prevents truncated/garbled output).
- OpenSSL3 CMAC update: hash only the requested slice (`startIndex..endIndex`) instead of the entire array.
- Linux `/dev/urandom` open: treat only `fd < 0` as error (0 is a valid descriptor).

## Why these changes are correct
- Signature copy offset
  - Our `signIntoByteArray(destination, destinationOffset)` contract writes the full signature at `destinationOffset`. Using `copyInto(destination, destinationOffset, destinationOffset)` erroneously interprets the offset as the source start index, truncating when `destinationOffset > 0`.
  - Correct usage is `copyInto(destination, destinationOffset, 0, size)`, i.e. copy from the start of the signature into the requested offset.
  - References (Kotlin stdlib):
    - Doc quote: "Copies this array or its subrange into the [destination] array and returns that array."
    - Param docs: "[destinationOffset] the position in the [destination] array to copy to... [startIndex] the beginning (inclusive) of the subrange to copy... [endIndex] the end (exclusive) of the subrange to copy"
    - Source signature: `public expect fun ByteArray.copyInto(destination: ByteArray, destinationOffset: Int = 0, startIndex: Int = 0, endIndex: Int = size): ByteArray`
      - https://raw.githubusercontent.com/JetBrains/kotlin/2.2.20/libraries/stdlib/common/src/generated/_Arrays.kt
      - API page: https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.collections/copy-into.html

- CMAC slice update (OpenSSL 3)
  - `EVP_MAC_update(ctx, data, datalen)` digests exactly the `datalen` bytes starting at `data`. Passing `safeAddressOf(0)` and `source.size` ignores the requested slice and can MAC unintended bytes.
  - Using `safeAddressOf(startIndex)` and `(endIndex - startIndex)` matches the streaming API’s `update(source, startIndex, endIndex)` contract.
  - Reference (OpenSSL 3.2 man page): exact quote — "EVP_MAC_update() adds datalen bytes from data to the MAC input."
    - https://raw.githubusercontent.com/openssl/openssl/openssl-3.2/doc/man3/EVP_MAC.pod

- `/dev/urandom` file descriptor check
  - POSIX `open(2)` returns a non-negative file descriptor on success; only `-1` indicates error. FD `0` is valid (stdin) and can be returned depending on process state.
  - Switching from `fd <= 0` to `fd < 0` avoids false-positive error handling.
  - Reference (Linux open(2) man page): exact quotes —
    - "The return value of open() is a file descriptor, a small, [..]"
    - "On success, open() returns a file descriptor (a nonnegative integer). On error, -1 is returned"
    - https://man7.org/linux/man-pages/man2/open.2.html

## Impact
- Correct signatures for callers who preallocate and write at non‑zero offsets.
- Correct CMACs for streaming/sliced updates; avoids accidental extra bytes.
- Avoids spurious failures on systems returning `fd = 0`.

## Validation
- JDK provider: compiles and JVM tests pass locally.
- Apple/OpenSSL3: common/metadata compilation succeeds.

## Follow‑ups (separate PR)
- Add constant‑time equals for MAC/CMAC/HMAC verifiers.
- Consider aligning AES‑GCM tag size policy.
- Provide PBKDF2 APIs that distinguish text vs binary input on JVM.