### PR TITLE
Docs(gradle-dependencies): fix dependencies typo

### DIFF
--- a/docs/dependencies/gradle-version-catalog.md
+++ b/docs/dependencies/gradle-version-catalog.md
@@ -44,7 +44,7 @@ Use version catalog in any of `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation(libc.cryptography.core)
+    implementation(libs.cryptography.core)
     implementation(libs.cryptography.provider.optimal)
 }
 ```


### PR DESCRIPTION
`libc.` -> `libs.`